### PR TITLE
Fixed issue with aiohttp request

### DIFF
--- a/asyncurban/urbandictionary.py
+++ b/asyncurban/urbandictionary.py
@@ -61,6 +61,7 @@ class UrbanDictionary:
                 response = await response.json()
             else:
                 raise UrbanConnectionError(response.status)
+        await self.session.close()
 
         if not response['list']:
             raise WordNotFoundError(term)


### PR DESCRIPTION
The library didn't seem to close its aiohttp sessions properly, resulting in a lot of errors about unclosed sessions in console. With one line of code, this issue has been fixed.